### PR TITLE
Feat: 회원정보 페이지 구현

### DIFF
--- a/frontend/src/app/user/layout.jsx
+++ b/frontend/src/app/user/layout.jsx
@@ -2,7 +2,7 @@ import Header from '@/components/calendar/header';
 import '@/styles/globals.css';
 
 export const metadata = {
-    title: '회원정보 | Schedule Manager',
+    title: '회원 정보 | Schedule Manager',
     description: '일정 관리 프로젝트',
 };
 

--- a/frontend/src/app/user/layout.jsx
+++ b/frontend/src/app/user/layout.jsx
@@ -1,0 +1,15 @@
+import Header from '@/components/calendar/header';
+import '@/styles/globals.css';
+
+export const metadata = {
+    title: '회원정보 | Schedule Manager',
+    description: '일정 관리 프로젝트',
+};
+
+export default function UserInfoLayout({ children }) {
+    return (
+        <Header>
+            {children}
+        </Header>
+    );
+}

--- a/frontend/src/app/user/page.jsx
+++ b/frontend/src/app/user/page.jsx
@@ -1,0 +1,45 @@
+"use client"
+
+import BigButton from '@/components/common/big-button';
+import styles from '@/styles/pages/user.module.css';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+const UserInfo = () => {
+    const router = useRouter();
+    const User = "abc123123@naver.com";
+    const [password, setPassword] = useState();
+
+    const handleInputChange = (e) => {
+        setPassword(e.target.value);
+    }
+
+    const handlePwCheck = () => {
+        alert(`비밀번호: ${password}`);
+        router.push('/find/changePassword');
+    }
+
+    const handleClick = () => {
+        confirm("정말 탈퇴하시겠습니까?");
+    };
+
+    return (
+        <div className={styles.main}>
+            <h1>회원 정보</h1>
+            <div className={styles.div}>
+                <p>아이디 :</p>
+                <p>{User}</p>
+            </div>
+            <div className={styles.div}>
+                <p>비밀번호 :</p>
+                <span>
+                    <input type='password' placeholder='PASSWORD' onChange={handleInputChange}/>
+                    <button onClick={handlePwCheck}>변경</button>
+                </span>
+            </div>
+            <BigButton className={styles.deleteButton} onClick={handleClick}>회원 탈퇴</BigButton>
+        </div>
+    )
+}
+
+export default UserInfo;

--- a/frontend/src/components/calendar/header.jsx
+++ b/frontend/src/components/calendar/header.jsx
@@ -1,17 +1,26 @@
+"use client";
+
 import styles from '@/styles/calendar/header.module.css';
 
 import Bell from '@heroicons/react/24/solid/BellIcon';
 import User from '@heroicons/react/24/solid/UserIcon';
+import { useRouter } from 'next/navigation';
 
 export default function Header({
     children
 }) {
+    const router = useRouter();
+
+    const handleUserPage = (e) => {
+        router.push('/user');
+    }
+
     return (
         <div className={styles.div}>
             <header className={styles.header}>
-                <Bell className={styles.icons} />
+                <Bell className={styles.icons}/>
                 <h1 className={styles.title}>Schedule Manager</h1>
-                <User className={styles.icons} />
+                <User className={styles.icons} onClick={handleUserPage}/>
             </header>
             <main className={styles.main}>
                 {children}

--- a/frontend/src/styles/pages/user.module.css
+++ b/frontend/src/styles/pages/user.module.css
@@ -1,0 +1,70 @@
+.main {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1.5rem;
+    width: 30vw;
+    height: 90vh;
+    margin: auto;
+}
+
+.main h1 {
+    font-size: 3.5rem;
+    margin-bottom: 3.5rem;
+}
+
+.div {
+    width: 100%;
+    font-size: 1.5rem;
+    text-align: center;
+    border-bottom: 2px solid #6c727f;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px;
+}
+
+.div span {
+    width: 81%;
+}
+
+.div input {
+    width: 80%;
+    margin: 0;
+    padding: 0.75rem;
+    font-size: 1rem;
+    border: none;
+    font-family: var(--font-paperlogy);
+    font-weight: 500;
+}
+
+.div button {
+    background-color: var(--color-background);
+    width: 20%;
+    margin: 0;
+    padding: 0.5rem;
+    font-size: 1.3rem;
+    font-family: var(--font-paperlogy);
+    font-weight: 500;
+    border: 0.125rem solid var(--color-neutral);
+    border-radius: 0.75rem;
+    cursor: pointer;
+    transition: border 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.div button:hover {
+    border: 0.125rem solid var(--color-text);
+    box-shadow: 0 0 5px var(--color-primary);
+}
+
+.div button:active {
+    background-color: #f8f9fa;
+    border-color: var(--color-primary);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1) inset;
+}
+
+.deleteButton {
+    width: 20vw;
+    margin: 3rem 0 2rem 0;
+}


### PR DESCRIPTION
## 📝 작업 내용
- [✔️] header의 user 아이콘 클릭 시 회원정보 페이지로 이동하기
- [✔️] 회원정보 페이지 구현

### 🖥️ 스크린샷 (선택)
- 회원정보 페이지 (이메일은 임시로 지정)
![image](https://github.com/user-attachments/assets/a6a232a4-fe3f-486b-86e5-6c697236cd07)

## 💬 리뷰 요구사항(선택)
비밀번호 입력 후 변경 페이지 이동 시, /find/changePassword 페이지로 이동하도록 했습니다.